### PR TITLE
Add mod config page

### DIFF
--- a/core/core.lua
+++ b/core/core.lua
@@ -113,9 +113,14 @@ local function concatAuthors(authors)
 end
 
 SMODS.customUIElements = {}
+SMODS.customSettingsElements = {}
 
 function SMODS.registerUIElement(modID, uiElements)
 	SMODS.customUIElements[modID] = uiElements
+end
+
+function SMODS.registerSettingsElement(modID, uiElements)
+	SMODS.customSettingsElements[modID] = uiElements
 end
 
 function create_UIBox_mods(args)
@@ -213,6 +218,10 @@ function create_UIBox_mods(args)
 									}
 								end
 							},
+							(SMODS.customSettingsElements[G.ACTIVE_MOD_UI.id] and {
+								label = "Config",
+								tab_definition_function = SMODS.customSettingsElements[G.ACTIVE_MOD_UI.id]
+							})
 						}
 					})
 				}

--- a/core/overrides.lua
+++ b/core/overrides.lua
@@ -973,7 +973,6 @@ function poll_edition(_key, _mod, _no_neg, _guaranteed, _options)
 		else
 			for _, v in ipairs(G.P_CENTER_POOLS.Edition) do
 				if v.in_shop then
-					sendDebugMessage(v.key)
 					table.insert(_options, v.key)
 				end
 			end

--- a/lovely/menu.toml
+++ b/lovely/menu.toml
@@ -1,0 +1,26 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = 0
+
+[[patches]]
+[patches.pattern]
+target = "functions/UI_definitions.lua"
+pattern = '''local main_menu = nil'''
+position = "after"
+payload = '''local mods = nil'''
+match_indent = true
+[[patches]]
+[patches.pattern]
+target = "functions/UI_definitions.lua"
+pattern = '''main_menu = UIBox_button{ label = {localize('b_main_menu')}, button = "go_to_menu", minw = 5}'''
+position = "after"
+payload = '''mods = UIBox_button{ label = {localize('b_mods')}, button = "mods_button", minw = 5}'''
+match_indent = true
+[[patches]]
+[patches.pattern]
+target = "functions/UI_definitions.lua"
+pattern = '''main_menu,'''
+position = "after"
+payload = '''mods,'''
+match_indent = true

--- a/lovely/palette.toml
+++ b/lovely/palette.toml
@@ -25,7 +25,7 @@ match_indent = true
 [[patches]]
 [patches.pattern]
 target = "functions/UI_definitions.lua"
-pattern = '''credits'''
+pattern = '''your_collection,'''
 position = "before"
 payload = '''colours,'''
 match_indent = true


### PR DESCRIPTION
- Adds a mod config page, that is configured through use of `SMODS.registerSettingsElement(key, function)`, where the function returns a ui node
- Adds a mods button to the escape menu during a run to allow for on the fly adjustments

*There is some sneaky cleanup with edition logging and the card colours button placement too that I accidentally commited (:*